### PR TITLE
fix(analytics): SKETCH-184 Handle 'InsertComponent' event from recent Sketch versions in analytics

### DIFF
--- a/scripts/gui-pack/publish.js
+++ b/scripts/gui-pack/publish.js
@@ -57,10 +57,12 @@ const getLastPublishDate = async () => {
  */
 const getPublishDate = async projectId =>
   new Date(
-    (await abstract.commits.list({
-      projectId,
-      branchId: 'master',
-    }))[0].time,
+    (
+      await abstract.commits.list({
+        projectId,
+        branchId: 'master',
+      })
+    )[0].time,
   );
 
 /**
@@ -286,7 +288,10 @@ const publish = async () => {
       ]);
 
       console.log('✒️  Generating RSS files for libraries');
-      await generateRSSFiles(changedFiles.filter(({ isLibrary }) => isLibrary), buildDirName);
+      await generateRSSFiles(
+        changedFiles.filter(({ isLibrary }) => isLibrary),
+        buildDirName,
+      );
 
       console.log('👆  Pushing files to remote');
       shell.exec(

--- a/src/sketch/handler/analytics/symbolListener.js
+++ b/src/sketch/handler/analytics/symbolListener.js
@@ -35,7 +35,10 @@ const isAdgLibrary = libraryId =>
  * @param {object} context - Sketch context.
  */
 export const onHandlerLostFocus = context => {
-  if (context.actionContext.name == 'InsertSymbol') {
+  if (
+    context.actionContext.name == 'InsertSymbol' ||
+    context.actionContext.name == 'InsertComponent'
+  ) {
     const [{ master }] = Document.getSelectedDocument().selectedLayers.layers;
     const { name: libraryName, id: libraryId } = master.getLibrary();
 

--- a/src/sketch/handler/analytics/symbolListener.js
+++ b/src/sketch/handler/analytics/symbolListener.js
@@ -15,6 +15,13 @@ import { SETTING_ADG_LIBRARY_IDS } from '../../util/settings';
 const { Document } = Dom;
 
 /**
+ * @param {string} libraryId Sketch ID of the library we're installing.
+ * @returns {boolean} Whether the symbol we're inserting comes from an ADG library.
+ */
+const isAdgLibrary = libraryId =>
+  Settings.settingForKey(SETTING_ADG_LIBRARY_IDS).includes(libraryId);
+
+/**
  * Handle the 'lost focus' event.
  *
  * This is our shortcut to figuring out when a symbol has been inserted. We have to do this, because
@@ -29,11 +36,10 @@ const { Document } = Dom;
  */
 export const onHandlerLostFocus = context => {
   if (context.actionContext.name == 'InsertSymbol') {
-    const adgLibraryIds = Settings.settingForKey(SETTING_ADG_LIBRARY_IDS);
     const [{ master }] = Document.getSelectedDocument().selectedLayers.layers;
     const { name: libraryName, id: libraryId } = master.getLibrary();
 
-    if (adgLibraryIds.includes(libraryId)) {
+    if (isAdgLibrary(libraryId)) {
       event(context, CATEGORY_SYMBOL, `${libraryName} / ${master.name}`, LABEL_GUI_PACK);
     }
 
@@ -54,11 +60,10 @@ export const onHandlerLostFocus = context => {
  * @param {object} context - Sketch context.
  */
 export const onUnlinkFromLibrary = context => {
-  const adgLibraryIds = Settings.settingForKey(SETTING_ADG_LIBRARY_IDS);
   const [{ master }] = Document.getSelectedDocument().selectedLayers.layers;
   const { name: libraryName, id: libraryId } = master.getLibrary();
 
-  if (adgLibraryIds.includes(libraryId)) {
+  if (isAdgLibrary(libraryId)) {
     event(context, CATEGORY_UNLINK, `${libraryName} / ${master.name}`, LABEL_GUI_PACK);
   }
 };
@@ -75,14 +80,13 @@ export const onUnlinkFromLibrary = context => {
  * @param {object} context - Sketch context.
  */
 export const onConvertSymbolOrDetachInstances = context => {
-  const adgLibraryIds = Settings.settingForKey(SETTING_ADG_LIBRARY_IDS);
   const [{ master }] = Document.getSelectedDocument().selectedLayers.layers;
   const library = master.getLibrary();
 
   if (library) {
     const { name: libraryName, id: libraryId } = library;
 
-    if (adgLibraryIds.includes(libraryId)) {
+    if (isAdgLibrary(libraryId)) {
       event(context, CATEGORY_UNLINK, `${libraryName} / ${master.name}`, LABEL_GUI_PACK);
     }
   }

--- a/src/sketch/handler/fonts/installFonts.js
+++ b/src/sketch/handler/fonts/installFonts.js
@@ -101,9 +101,9 @@ const installFonts = async () => {
   const fiber = Async.createFiber();
 
   try {
-    const installedFonts = toArray(NSFontManager.sharedFontManager().availableFontFamilies()).map(
-      fontName => String(fontName),
-    );
+    const installedFonts = toArray(
+      NSFontManager.sharedFontManager().availableFontFamilies(),
+    ).map(fontName => String(fontName));
     const promises = [];
 
     if (!installedFonts.includes(FONT_NAME_ROBOTO)) {


### PR DESCRIPTION

A few API versions ago, Sketch changed the name of the event it sends when we insert a component from `InsertSymbol` to `InsertComponent`. This broke our analytics for symbol insertions.

In order to maintain backwards compatibility, we have added the new name as an option for the handler.